### PR TITLE
fix: check if response is json before parsing

### DIFF
--- a/src/model/client/FetchClient.ts
+++ b/src/model/client/FetchClient.ts
@@ -1,5 +1,6 @@
-import {ClientConfig, ClientRequest, OptionsWithBody} from '@/model/client/AbstractClient.types';
+import {type ClientConfig, type ClientRequest, type OptionsWithBody} from '@/model/client/AbstractClient.types';
 import {AbstractClient} from '@/model/client/AbstractClient';
+import {isJson} from '@/model/client/helper/isJson';
 import {isOfType} from '@myparcel/ts-utils';
 
 export class FetchClient extends AbstractClient {
@@ -25,11 +26,13 @@ export class FetchClient extends AbstractClient {
     clearTimeout(id);
 
     if (response.body) {
-      if (response.headers.get('Content-Type')?.includes('application/json')) {
-        return response.json();
+      const text = await response.text();
+
+      if (response.headers.get('Content-Type')?.includes('application/json') && isJson(text)) {
+        return JSON.parse(text);
       }
 
-      return response.text();
+      return text;
     }
   };
 }

--- a/src/model/client/helper/isJson.spec.ts
+++ b/src/model/client/helper/isJson.spec.ts
@@ -1,0 +1,12 @@
+import {describe, expect, it} from 'vitest';
+import {isJson} from './isJson';
+
+describe('isJson', () => {
+  it('returns true when the data is JSON', () => {
+    expect(isJson('{}')).toBe(true);
+  });
+
+  it('returns false when the data is not JSON', () => {
+    expect(isJson('')).toBe(false);
+  });
+});

--- a/src/model/client/helper/isJson.ts
+++ b/src/model/client/helper/isJson.ts
@@ -1,0 +1,8 @@
+export const isJson = (data: string): boolean => {
+  try {
+    JSON.parse(data);
+    return true;
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
When a response returns with no content and `application/json` headers the response will not be parsed anymore