### PR TITLE
feat(client): support attachment responses

### DIFF
--- a/src/model/client/AbstractClient.spec.ts
+++ b/src/model/client/AbstractClient.spec.ts
@@ -14,6 +14,7 @@ import {POST_BODY_SHIPMENTS} from '@Test/mockData';
 import {TestDeleteEndpoint} from '@Test/endpoints/TestDeleteEndpoint';
 import {TestGet200Endpoint} from '@Test/endpoints/TestGet200Endpoint';
 import {TestGetAttachmentEndpoint} from '@Test/endpoints/TestGetAttachmentEndpoint';
+import {TestGetInlineContentEndpoint} from '@Test/endpoints/TestGetInlineContentEndpoint';
 import {TestGetTextEndpoint} from '@Test/endpoints/TestGetTextEndpoint';
 import {TestPostWithoutPropertyEndpoint} from '@Test/endpoints/TestPostWithoutPropertyEndpoint';
 import {TestPut204Endpoint} from '@Test/endpoints/TestPut204Endpoint';
@@ -296,7 +297,7 @@ describe('AbstractClient', () => {
     });
   });
 
-  it('handles receiving a response with a blob content ', async () => {
+  it('handles receiving a response with a blob content', async () => {
     expect.assertions(7);
 
     const sdk = createPublicSdk(new FetchClient(), [new TestGetAttachmentEndpoint()]);
@@ -313,6 +314,26 @@ describe('AbstractClient', () => {
     expect(result.statusText).toBe('OK');
 
     expect(fetchMock).toHaveBeenCalledWith('https://api.myparcel.nl/endpoint/attachment', {
+      headers: {
+        Accept: 'application/json',
+      },
+      method: 'GET',
+    });
+  });
+
+  it('handles receiving a response with content-disposition: inline header', async () => {
+    expect.assertions(4);
+
+    const sdk = createPublicSdk(new FetchClient(), [new TestGetInlineContentEndpoint()]);
+    const response = await sdk.getInline();
+
+    expect(response).toBe('"Test"');
+
+    const result = await fetchMock.mock.results[0].value;
+    expect(result.status).toBe(200);
+    expect(result.statusText).toBe('OK');
+
+    expect(fetchMock).toHaveBeenCalledWith('https://api.myparcel.nl/endpoint/inline', {
       headers: {
         Accept: 'application/json',
       },

--- a/src/model/client/AbstractClient.spec.ts
+++ b/src/model/client/AbstractClient.spec.ts
@@ -13,6 +13,7 @@ import {FetchClient} from '@/model/client/FetchClient';
 import {POST_BODY_SHIPMENTS} from '@Test/mockData';
 import {TestDeleteEndpoint} from '@Test/endpoints/TestDeleteEndpoint';
 import {TestGet200Endpoint} from '@Test/endpoints/TestGet200Endpoint';
+import {TestGetAttachmentEndpoint} from '@Test/endpoints/TestGetAttachmentEndpoint';
 import {TestGetTextEndpoint} from '@Test/endpoints/TestGetTextEndpoint';
 import {TestPostWithoutPropertyEndpoint} from '@Test/endpoints/TestPostWithoutPropertyEndpoint';
 import {TestPut204Endpoint} from '@Test/endpoints/TestPut204Endpoint';
@@ -290,6 +291,30 @@ describe('AbstractClient', () => {
     expect(fetchMock).toHaveBeenCalledWith('https://api.myparcel.nl/endpoint/text', {
       headers: {
         Accept: 'text/plain',
+      },
+      method: 'GET',
+    });
+  });
+
+  it('handles receiving a response with a blob content ', async () => {
+    expect.assertions(7);
+
+    const sdk = createPublicSdk(new FetchClient(), [new TestGetAttachmentEndpoint()]);
+    const response = await sdk.getAttachment();
+
+    // the Blob presented by vitest is not the same as the fetcher, so check for blob-like properties:
+    expect(response).toHaveProperty('size');
+    expect(response).toHaveProperty('type');
+    expect(response.size).toBe(6);
+    expect(response.type).toBe('image/jpeg');
+
+    const result = await fetchMock.mock.results[0].value;
+    expect(result.status).toBe(200);
+    expect(result.statusText).toBe('OK');
+
+    expect(fetchMock).toHaveBeenCalledWith('https://api.myparcel.nl/endpoint/attachment', {
+      headers: {
+        Accept: 'application/json',
       },
       method: 'GET',
     });

--- a/src/model/client/FetchClient.ts
+++ b/src/model/client/FetchClient.ts
@@ -26,6 +26,10 @@ export class FetchClient extends AbstractClient {
     clearTimeout(id);
 
     if (response.body) {
+      if (response.headers.get('Content-Disposition')?.includes('attachment')) {
+        return response.blob();
+      }
+
       const text = await response.text();
 
       if (response.headers.get('Content-Type')?.includes('application/json') && isJson(text)) {

--- a/test/endpoints/TestGetAttachmentEndpoint.ts
+++ b/test/endpoints/TestGetAttachmentEndpoint.ts
@@ -5,5 +5,4 @@ export class TestGetAttachmentEndpoint extends AbstractPublicEndpoint {
   public readonly method: HttpMethod = 'GET';
   public readonly name = 'getAttachment';
   public readonly path = 'endpoint/attachment';
-  public readonly property = 'none';
 }

--- a/test/endpoints/TestGetAttachmentEndpoint.ts
+++ b/test/endpoints/TestGetAttachmentEndpoint.ts
@@ -1,0 +1,9 @@
+import {AbstractPublicEndpoint} from '@/model';
+import {type HttpMethod} from '@/types';
+
+export class TestGetAttachmentEndpoint extends AbstractPublicEndpoint {
+  public readonly method: HttpMethod = 'GET';
+  public readonly name = 'getAttachment';
+  public readonly path = 'endpoint/attachment';
+  public readonly property = 'none';
+}

--- a/test/endpoints/TestGetInlineContentEndpoint.ts
+++ b/test/endpoints/TestGetInlineContentEndpoint.ts
@@ -1,0 +1,8 @@
+import {AbstractPublicEndpoint} from '@/model';
+import {type HttpMethod} from '@/types';
+
+export class TestGetInlineContentEndpoint extends AbstractPublicEndpoint {
+  public readonly method: HttpMethod = 'GET';
+  public readonly name = 'getInline';
+  public readonly path = 'endpoint/inline';
+}

--- a/test/fetch/examples/get-attachment.example.ts
+++ b/test/fetch/examples/get-attachment.example.ts
@@ -1,0 +1,13 @@
+// noinspection JSUnusedGlobalSymbols
+
+import {defineMockResponse} from '@Test/fetch/defineMockResponse';
+
+export default defineMockResponse({
+  match: (path: string, init?: RequestInit) => init?.method === 'GET' && path === '/endpoint/attachment',
+
+  response: () => ({
+    status: 200,
+    headers: new Headers({'Content-Type': 'image/jpeg', 'Content-Disposition': 'attachment; filename="test.jpg"'}),
+    body: 'blob',
+  }),
+});

--- a/test/fetch/examples/get-inline-content.example.ts
+++ b/test/fetch/examples/get-inline-content.example.ts
@@ -1,0 +1,13 @@
+// noinspection JSUnusedGlobalSymbols
+
+import {defineMockResponse} from '@Test/fetch/defineMockResponse';
+
+export default defineMockResponse({
+  match: (path: string, init?: RequestInit) => init?.method === 'GET' && path === '/endpoint/inline',
+
+  response: () => ({
+    status: 200,
+    headers: new Headers({'Content-Type': 'text/html', 'Content-Disposition': 'inline'}),
+    body: 'Test',
+  }),
+});


### PR DESCRIPTION
Ensures that responses with a non-text response get returned as a blob.