### PR TITLE
feat: return all content in data when no response property is defined

### DIFF
--- a/src/model/client/AbstractClient.spec.ts
+++ b/src/model/client/AbstractClient.spec.ts
@@ -9,6 +9,7 @@ import {TestGetTextEndpoint} from '@Test/endpoints/TestGetTextEndpoint';
 import {TestGetInlineContentEndpoint} from '@Test/endpoints/TestGetInlineContentEndpoint';
 import {TestGetAttachmentEndpoint} from '@Test/endpoints/TestGetAttachmentEndpoint';
 import {TestGet200Endpoint} from '@Test/endpoints/TestGet200Endpoint';
+import {TestGet200NoResponseProperty} from '@Test/endpoints/TestGet200NoResponseProperty';
 import {TestDeleteEndpoint} from '@Test/endpoints/TestDeleteEndpoint';
 import {UserException} from '@/model/exception/UserException';
 import {ApiException} from '@/model/exception/ApiException';
@@ -399,5 +400,15 @@ describe('AbstractClient', () => {
 
     expect(response).toHaveProperty('shipments', []);
     expect(response).toHaveProperty('results', 0);
+  });
+
+  it('returns all contents from data property when no property is defined', async () => {
+    expect.assertions(2);
+
+    const sdk = createPublicSdk(new FetchClient(), [new TestGet200NoResponseProperty()]);
+    const response = await sdk.get200NoResponseProperty();
+
+    expect(response).toHaveProperty('token', 'test');
+    expect(response).toHaveProperty('credentials', {username: 'test', password: 'test'});
   });
 });

--- a/src/model/client/AbstractClient.ts
+++ b/src/model/client/AbstractClient.ts
@@ -96,6 +96,11 @@ export abstract class AbstractClient {
 
     if (isOfType<ResponseWrapper<EndpointResponseBody<E>>>(response, 'data')) {
       const property = endpoint.getResponseProperty() as EndpointResponseProperty<E>;
+
+      if (typeof property === 'undefined') {
+        return response.data;
+      }
+
       let wrappedResponse: EndpointResponse<E> = response.data[property];
 
       // If the response is paginated, wrap it.

--- a/src/model/client/AbstractClient.ts
+++ b/src/model/client/AbstractClient.ts
@@ -97,7 +97,7 @@ export abstract class AbstractClient {
     if (isOfType<ResponseWrapper<EndpointResponseBody<E>>>(response, 'data')) {
       const property = endpoint.getResponseProperty() as EndpointResponseProperty<E>;
 
-      if (typeof property !== 'string') {
+      if (!property) {
         return response.data;
       }
 

--- a/src/model/client/AbstractClient.ts
+++ b/src/model/client/AbstractClient.ts
@@ -97,7 +97,7 @@ export abstract class AbstractClient {
     if (isOfType<ResponseWrapper<EndpointResponseBody<E>>>(response, 'data')) {
       const property = endpoint.getResponseProperty() as EndpointResponseProperty<E>;
 
-      if (typeof property === 'undefined') {
+      if (typeof property !== 'string') {
         return response.data;
       }
 

--- a/src/model/endpoint/AbstractEndpoint.types.ts
+++ b/src/model/endpoint/AbstractEndpoint.types.ts
@@ -15,7 +15,7 @@ export interface EndpointDefinition {
   headers?: RequestHeaders;
   parameters?: NoInfer<Record<string, string | number | boolean>>;
   path?: Record<string, string | number>;
-  response?: NoInfer<unknown[]> | PaginatedResponse<NoInfer<unknown[]>>;
+  response?: NoInfer<unknown[] | unknown> | PaginatedResponse<NoInfer<unknown[]>>;
 }
 
 export type CreateDefinition<D extends EndpointDefinition> = D;

--- a/src/model/endpoint/AbstractEndpoint.types.ts
+++ b/src/model/endpoint/AbstractEndpoint.types.ts
@@ -1,5 +1,6 @@
 import {type RequestHeaders} from '@/types/request.types';
 import {type NoInfer} from '@/types/global.types';
+import { type OneOrMore } from '@myparcel/ts-utils';
 
 type Pagination = {
   page?: number;
@@ -15,7 +16,7 @@ export interface EndpointDefinition {
   headers?: RequestHeaders;
   parameters?: NoInfer<Record<string, string | number | boolean>>;
   path?: Record<string, string | number>;
-  response?: NoInfer<unknown[] | unknown> | PaginatedResponse<NoInfer<unknown[]>>;
+  response?: NoInfer<OneOrMore<unknown>> | PaginatedResponse<NoInfer<unknown[]>>;
 }
 
 export type CreateDefinition<D extends EndpointDefinition> = D;

--- a/test/endpoints/TestGet200NoResponseProperty.ts
+++ b/test/endpoints/TestGet200NoResponseProperty.ts
@@ -1,0 +1,6 @@
+import {AbstractPublicEndpoint} from '@/model';
+
+export class TestGet200NoResponseProperty extends AbstractPublicEndpoint {
+  public readonly name = 'get200NoResponseProperty';
+  public readonly path = 'get200NoResponseProperty';
+}

--- a/test/fetch/examples/get-200-no-response-property.ts
+++ b/test/fetch/examples/get-200-no-response-property.ts
@@ -1,0 +1,21 @@
+// noinspection JSUnusedGlobalSymbols
+
+import {defineMockResponse} from '@Test/fetch/defineMockResponse';
+
+export default defineMockResponse({
+  match: (path: string, init?: RequestInit) => init?.method === 'GET' && path.startsWith('/get200NoResponseProperty'),
+
+  response: () => ({
+    headers: {'Content-Type': 'application/json'},
+    status: 200,
+    body: {
+      data: {
+        token: 'test',
+        credentials: {
+          username: 'test',
+          password: 'test',
+        },
+      },
+    },
+  }),
+});


### PR DESCRIPTION
Allow the response type not to be an object since it can also return any type when no `data` is found in the response