### PR TITLE
feat: add option to overwrite timeout for individual endpoints

### DIFF
--- a/src/model/client/FetchClient.ts
+++ b/src/model/client/FetchClient.ts
@@ -9,13 +9,14 @@ export class FetchClient extends AbstractClient {
   }
 
   protected request: ClientRequest = async (endpoint, options) => {
+    const timeout = endpoint.getTimeout() ?? options.timeout;
     const timeoutController = new AbortController();
-    const id = setTimeout(() => timeoutController.abort(), options.timeout);
+    const id = setTimeout(() => timeoutController.abort(), timeout);
 
     const config: RequestInit = {
       method: endpoint.method,
       headers: options.headers,
-      ...(options.timeout && {signal: timeoutController.signal}),
+      ...(timeout && {signal: timeoutController.signal}),
     };
 
     if (isOfType<OptionsWithBody<typeof endpoint>>(options, 'body')) {

--- a/src/model/endpoint/AbstractEndpoint.ts
+++ b/src/model/endpoint/AbstractEndpoint.ts
@@ -36,6 +36,12 @@ export abstract class AbstractEndpoint<D = EndpointDefinition> {
   public readonly responseProperty: string | undefined;
 
   /**
+   * Timeout in milliseconds.
+   * This is used to override the default timeout of the client.
+   */
+  public readonly timeout: number | undefined;
+
+  /**
    * Used to expose EndpointDefinition type.
    */
   public declare readonly definition: D;
@@ -73,5 +79,9 @@ export abstract class AbstractEndpoint<D = EndpointDefinition> {
 
   public getResponseProperty(): AbstractEndpoint['responseProperty'] {
     return this.responseProperty ?? this.property;
+  }
+
+  public getTimeout(): AbstractEndpoint['timeout'] {
+    return this.timeout;
   }
 }

--- a/src/model/endpoint/AbstractEndpoint.types.ts
+++ b/src/model/endpoint/AbstractEndpoint.types.ts
@@ -17,6 +17,7 @@ export interface EndpointDefinition {
   parameters?: NoInfer<Record<string, string | number | boolean>>;
   path?: Record<string, string | number>;
   response?: NoInfer<OneOrMore<unknown>> | PaginatedResponse<NoInfer<unknown[]>>;
+  timeout?: number;
 }
 
 export type CreateDefinition<D extends EndpointDefinition> = D;

--- a/test/endpoints/TestGetExtendedTimeout.ts
+++ b/test/endpoints/TestGetExtendedTimeout.ts
@@ -1,0 +1,9 @@
+import {AbstractPrivateEndpoint} from '@/model';
+
+export class TestGetExtendedTimeout extends AbstractPrivateEndpoint {
+  public readonly method = 'GET';
+  public readonly name = 'getExtendedTimeout';
+  public readonly path = 'timeout';
+  public readonly property = 'endpoint';
+  public readonly timeout = 200;
+}

--- a/test/fetch/examples/get-extended-timeout.ts
+++ b/test/fetch/examples/get-extended-timeout.ts
@@ -1,0 +1,23 @@
+// noinspection JSUnusedGlobalSymbols
+
+import {defineMockResponse} from '@Test/fetch/defineMockResponse';
+
+export default defineMockResponse({
+  match: (path: string, init?: RequestInit) => init?.method === 'GET' && path === '/timeout',
+
+  response: () => {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve({
+          headers: {'Content-Type': 'application/json'},
+          status: 200,
+          body: {
+            data: {
+              endpoint: [],
+            },
+          },
+        });
+      }, 199);
+    });
+  },
+});


### PR DESCRIPTION
Allows you to overwrite the default timeout for slow endpoints specifically.