### PR TITLE
fix: allow passing recipient email when posting shipments

### DIFF
--- a/src/endpoints/private/shipments/Shipment.types.ts
+++ b/src/endpoints/private/shipments/Shipment.types.ts
@@ -6,7 +6,10 @@ import {
   type PackageTypeId,
   type ShipmentStatus,
 } from '@myparcel/constants';
-import {type Address, type AddressWithContactDetails, type RetailLocation} from '../../../types';
+import {
+  type AddressWithContactDetails,
+  type RetailLocation,
+} from '../../../types';
 import {type IntBoolean, type Price, type WithRequired} from '@/types';
 
 export interface PostedShipmentReference {
@@ -103,7 +106,9 @@ export interface ShipmentPostData {
   options?: ShipmentOptions;
   physical_properties?: PhysicalProperties;
   pickup?: ShipmentPickup | null;
-  recipient: WithRequired<Address, 'number'> | WithRequired<Address, 'street'>;
+  recipient:
+    | WithRequired<AddressWithContactDetails, 'number'>
+    | WithRequired<AddressWithContactDetails, 'street'>;
   reference_identifier?: number | string;
   shop_id?: number;
   status?: ShipmentStatus;

--- a/src/model/client/AbstractClient.spec.ts
+++ b/src/model/client/AbstractClient.spec.ts
@@ -195,7 +195,7 @@ describe('AbstractClient', () => {
           'Content-Type': 'application/vnd.shipment+json;charset=utf-8;version=1.1',
         },
         method: 'POST',
-        body: '{"data":{"shipments":[{"carrier":1,"options":{"package_type":1,"delivery_type":2},"recipient":{"cc":"NL","city":"Hoofddorp","person":"Ms. Parcel","street":"Antareslaan 31","postal_code":"2132 JE"}}]}}',
+        body: '{"data":{"shipments":[{"carrier":1,"options":{"package_type":1,"delivery_type":2},"recipient":{"cc":"NL","city":"Hoofddorp","person":"Ms. Parcel","street":"Antareslaan 31","postal_code":"2132 JE","email":"example@myparcel.nl"}}]}}',
       });
     });
 
@@ -209,7 +209,7 @@ describe('AbstractClient', () => {
 
       expect(fetchMock).toHaveBeenCalledWith('https://api.myparcel.nl/endpoint', {
         method: 'POST',
-        body: '{"data":{"carrier":1,"options":{"package_type":1,"delivery_type":2},"recipient":{"cc":"NL","city":"Hoofddorp","person":"Ms. Parcel","street":"Antareslaan 31","postal_code":"2132 JE"}}}',
+        body: '{"data":{"carrier":1,"options":{"package_type":1,"delivery_type":2},"recipient":{"cc":"NL","city":"Hoofddorp","person":"Ms. Parcel","street":"Antareslaan 31","postal_code":"2132 JE","email":"example@myparcel.nl"}}}',
         headers: {
           Accept: 'application/json',
           'Content-Type': 'application/json',

--- a/test/mockData.ts
+++ b/test/mockData.ts
@@ -15,6 +15,7 @@ export const POST_BODY_SHIPMENTS: EndpointBody<PostShipments> = [
       person: 'Ms. Parcel',
       street: 'Antareslaan 31',
       postal_code: '2132 JE',
+      email: 'example@myparcel.nl',
     },
   },
 ];


### PR DESCRIPTION
I noticed a breaking change in the `PostShipment` `recipient` type definition after upgrading from v3.0.0, where I wasn't allowed to pass an `email` field anymore. It looks like it got introduced in https://github.com/myparcelnl/js-sdk/pull/135 where the `recipient` type got updated.
This pull request should fix that. 

I also verified that both the `email` and `phone` fields should still be valid fields on the recipient object here; https://developer.myparcel.nl/api-reference/06.shipments.html#_6-b-4