### PR TITLE
fix!: FE-2118 - update the DeleteCarrierOptions path

### DIFF
--- a/src/endpoints/private/carrier-options/DeleteCarrierOptions.ts
+++ b/src/endpoints/private/carrier-options/DeleteCarrierOptions.ts
@@ -1,13 +1,12 @@
-import {AbstractPrivateEndpoint} from '@/model/endpoint/AbstractPrivateEndpoint';
-import {type CarrierId} from '@myparcel/constants';
-import {type CreateDefinition} from '@/model/endpoint/AbstractEndpoint.types';
 import {type HttpMethod} from '@/types';
+import {AbstractPrivateEndpoint} from '@/model/endpoint/AbstractPrivateEndpoint';
+import {type CreateDefinition} from '@/model/endpoint/AbstractEndpoint.types';
 
 type DeleteCarrierOptionsDefinition = CreateDefinition<{
   name: typeof DeleteCarrierOptions.name;
   path: {
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    carrier_id: CarrierId;
+    contract_id: number;
     // eslint-disable-next-line @typescript-eslint/naming-convention
     account_id: number;
   };
@@ -16,6 +15,6 @@ type DeleteCarrierOptionsDefinition = CreateDefinition<{
 export class DeleteCarrierOptions extends AbstractPrivateEndpoint<DeleteCarrierOptionsDefinition> {
   public readonly method: HttpMethod = 'DELETE';
   public readonly name = 'deleteCarrierOption';
-  public readonly path = 'accounts/:account_id/carrier_options/:carrier_id';
+  public readonly path = 'accounts/:account_id/carrier_options/:contract_id';
   public readonly property = 'carrier_options';
 }


### PR DESCRIPTION
[FE-2118](https://myparcelnl.atlassian.net/browse/FE-2118)

The path was asking for a carrier_id while we need a contract_id


[FE-2118]: https://myparcelnl.atlassian.net/browse/FE-2118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ