### PR TITLE
feat: return pdf responses as blobs

### DIFF
--- a/src/model/client/AbstractClient.spec.ts
+++ b/src/model/client/AbstractClient.spec.ts
@@ -6,6 +6,7 @@ import {createFetchMock} from '@Test/fetch/createFetchMock';
 import {TestPut204Endpoint} from '@Test/endpoints/TestPut204Endpoint';
 import {TestPostWithoutPropertyEndpoint} from '@Test/endpoints/TestPostWithoutPropertyEndpoint';
 import {TestGetTextEndpoint} from '@Test/endpoints/TestGetTextEndpoint';
+import {TestGetPdfEndpoint} from '@Test/endpoints/TestGetPdfEndpoint';
 import {TestGetPaginatedSizeEndpoint} from '@Test/endpoints/TestGetPaginatedSizeEndpoint';
 import {TestGetPaginatedResultsEndpoint} from '@Test/endpoints/TestGetPaginatedResultsEndpoint';
 import {TestGetPaginatedPageEndpoint} from '@Test/endpoints/TestGetPaginatedPageEndpoint';
@@ -344,6 +345,33 @@ describe('AbstractClient', () => {
     expect(result.status).toBe(200);
 
     expect(fetchMock).toHaveBeenCalledWith('https://api.myparcel.nl/endpoint/attachment', {
+      headers: {
+        Accept: 'application/json',
+      },
+      method: 'GET',
+    });
+  });
+
+  it('handles receiving a response with content-type application/pdf as a blob', async () => {
+    expect.assertions(5);
+
+    const sdk = createPublicSdk(new FetchClient(), [new TestGetPdfEndpoint()]);
+    const response = await sdk.getPdf();
+
+    // the Blob presented by vitest is not the same as the fetcher, so check for blob-like properties:
+    const ofType = isOfType<Blob>(response, 'size');
+
+    expect(ofType).toBe(true);
+
+    if (ofType) {
+      expect(response.size).toBe(6);
+      expect(response.type).toBe('application/pdf');
+    }
+
+    const result = await fetchMock.mock.results[0].value;
+    expect(result.status).toBe(200);
+
+    expect(fetchMock).toHaveBeenCalledWith('https://api.myparcel.nl/pdf', {
       headers: {
         Accept: 'application/json',
       },

--- a/src/model/client/FetchClient.ts
+++ b/src/model/client/FetchClient.ts
@@ -32,7 +32,10 @@ export class FetchClient extends AbstractClient {
     clearTimeout(id);
 
     if (response.body) {
-      if (response.headers.get('Content-Disposition')?.includes('attachment')) {
+      if (
+        response.headers.get('Content-Disposition')?.includes('attachment') ||
+        response.headers.get('Content-Type')?.includes('application/pdf')
+      ) {
         return response.blob();
       }
 

--- a/test/endpoints/TestGetPdfEndpoint.ts
+++ b/test/endpoints/TestGetPdfEndpoint.ts
@@ -1,0 +1,8 @@
+import {type HttpMethod} from '@/types';
+import {AbstractPublicEndpoint} from '@/model';
+
+export class TestGetPdfEndpoint extends AbstractPublicEndpoint {
+  public readonly method: HttpMethod = 'GET';
+  public readonly name = 'getPdf';
+  public readonly path = 'pdf';
+}

--- a/test/fetch/examples/get-pdf.example.ts
+++ b/test/fetch/examples/get-pdf.example.ts
@@ -1,0 +1,13 @@
+// noinspection JSUnusedGlobalSymbols
+
+import {defineMockResponse} from '@Test/fetch/defineMockResponse';
+
+export default defineMockResponse({
+  match: (path: string, init?: RequestInit) => init?.method === 'GET' && path === '/pdf',
+
+  response: () => ({
+    status: 200,
+    headers: new Headers({'Content-Type': 'application/pdf'}),
+    body: 'blob'
+  }),
+});


### PR DESCRIPTION
Return a response as a blob when the content type is set as `application/pdf`