### PR TITLE
fix(fetchclient): Keep the abortcontroller within the fetchclient

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,4 +1,0 @@
-coverage:
-  ignore:
-    - "src/**/*.spec.ts"
-    - "src/**/*.test.ts"

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,4 @@
+coverage:
+  ignore:
+    - "src/**/*.spec.ts"
+    - "src/**/*.test.ts"

--- a/src/createMyParcelSdk.spec.ts
+++ b/src/createMyParcelSdk.spec.ts
@@ -65,7 +65,8 @@ describe('createMyParcelSdk', () => {
             if (signal.aborted) {
               return;
             }
-            reject(new Error('Not aborted (unexpected)'));
+
+            reject();
           }, 20);
         });
       });

--- a/src/createMyParcelSdk.spec.ts
+++ b/src/createMyParcelSdk.spec.ts
@@ -87,7 +87,7 @@ describe('createMyParcelSdk', () => {
         [getEndpoint],
       );
 
-      await expect(sdk.getEndpoint()).rejects.toThrowError(/aborted/i);
+      await expect(sdk.getEndpoint()).rejects.toThrowError('The operation was aborted.');
 
       expect(fetchMock).toHaveBeenCalledOnce();
     });
@@ -106,7 +106,8 @@ describe('createMyParcelSdk', () => {
             if (signal.aborted) {
               return;
             }
-            reject(new Error('Not aborted (unexpected)'));
+
+            reject();
           }, 20);
         });
       });
@@ -131,7 +132,7 @@ describe('createMyParcelSdk', () => {
         return options;
       });
 
-      await expect(sdk.getEndpoint()).rejects.toThrowError(/aborted/i);
+      await expect(sdk.getEndpoint()).rejects.toThrowError('The operation was aborted.');
 
       expect(fetchMock).toHaveBeenCalledOnce();
     });

--- a/src/createPrivateSdk.spec.ts
+++ b/src/createPrivateSdk.spec.ts
@@ -84,7 +84,7 @@ describe('createPrivateSdk', () => {
         [getEndpoint],
       );
 
-      await expect(sdk.getEndpoint()).rejects.toThrowError(/aborted/i);
+      await expect(sdk.getEndpoint()).rejects.toThrowError('The operation was aborted.');
 
       expect(fetchMock).toHaveBeenCalledOnce();
     });
@@ -103,7 +103,8 @@ describe('createPrivateSdk', () => {
             if (signal.aborted) {
               return;
             }
-            reject(new Error('Not aborted (unexpected)'));
+
+            reject();
           }, 20);
         });
       });
@@ -128,7 +129,7 @@ describe('createPrivateSdk', () => {
         return options;
       });
 
-      await expect(sdk.getEndpoint()).rejects.toThrowError(/aborted/i);
+      await expect(sdk.getEndpoint()).rejects.toThrowError('The operation was aborted.');
 
       expect(fetchMock).toHaveBeenCalledOnce();
     });

--- a/src/createPrivateSdk.spec.ts
+++ b/src/createPrivateSdk.spec.ts
@@ -7,6 +7,24 @@ import {createPrivateSdk} from '@/createPrivateSdk';
 
 describe('createPrivateSdk', () => {
   const fetchMock = createFetchMock();
+  const fetchMockwithTimeout = (url: string, config: RequestInit) => {
+    // Simulate aborting after a delay
+    const signal = config.signal as AbortSignal;
+
+    return new Promise((_, reject) => {
+      signal?.addEventListener('abort', () => {
+        reject(new DOMException('The operation was aborted.', 'AbortError'));
+      });
+
+      setTimeout(() => {
+        if (signal.aborted) {
+          return;
+        }
+
+        reject(new Error('Some other fetch error'));
+      }, 20);
+    });
+  };
 
   beforeEach(() => {
     fetchMock.mockClear();
@@ -49,24 +67,7 @@ describe('createPrivateSdk', () => {
 
   describe('timeout', () => {
     it('should handle timeout', async () => {
-      fetchMock.mockImplementation((url, config) => {
-        // Simulate aborting after a delay
-        const signal = config.signal as AbortSignal;
-
-        return new Promise((_, reject) => {
-          signal?.addEventListener('abort', () => {
-            reject(new DOMException('The operation was aborted.', 'AbortError'));
-          });
-
-          setTimeout(() => {
-            if (signal.aborted) {
-              return;
-            }
-
-            reject();
-          }, 20);
-        });
-      });
+      fetchMock.mockImplementation(fetchMockwithTimeout);
 
       expect.assertions(2);
 
@@ -90,24 +91,7 @@ describe('createPrivateSdk', () => {
     });
 
     it('should handle timeout with a request interceptor given', async () => {
-      fetchMock.mockImplementation((_, config) => {
-        // Simulate aborting after a delay
-        const signal = config.signal as AbortSignal;
-
-        return new Promise((_, reject) => {
-          signal?.addEventListener('abort', () => {
-            reject(new DOMException('The operation was aborted.', 'AbortError'));
-          });
-
-          setTimeout(() => {
-            if (signal.aborted) {
-              return;
-            }
-
-            reject();
-          }, 20);
-        });
-      });
+      fetchMock.mockImplementation(fetchMockwithTimeout);
 
       expect.assertions(2);
 
@@ -130,6 +114,30 @@ describe('createPrivateSdk', () => {
       });
 
       await expect(sdk.getEndpoint()).rejects.toThrowError('The operation was aborted.');
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
+    it('should not abort before the timeout is over', async () => {
+      fetchMock.mockImplementation(fetchMockwithTimeout);
+
+      expect.assertions(2);
+
+      const getEndpoint = new TestGet200PrivateEndpoint();
+
+      const sdk = createPrivateSdk(
+        new FetchClient({
+          headers: {
+            Authorization: 'bearer apiKey',
+          },
+          options: {
+            timeout: 50,
+          },
+        }),
+        [getEndpoint],
+      );
+
+      await expect(sdk.getEndpoint()).rejects.toThrowError('Some other fetch error');
 
       expect(fetchMock).toHaveBeenCalledOnce();
     });

--- a/src/createPrivateSdk.spec.ts
+++ b/src/createPrivateSdk.spec.ts
@@ -62,7 +62,8 @@ describe('createPrivateSdk', () => {
             if (signal.aborted) {
               return;
             }
-            reject(new Error('Not aborted (unexpected)'));
+
+            reject();
           }, 20);
         });
       });

--- a/src/model/client/AbstractClient.spec.ts
+++ b/src/model/client/AbstractClient.spec.ts
@@ -630,8 +630,13 @@ describe('AbstractClient', () => {
       expect(interceptor).toHaveBeenCalledTimes(1);
       expect(interceptor).toHaveBeenCalledWith(
         expect.objectContaining({
-          method: 'GET',
-          headers: expect.any(Object),
+          headers: {
+            Accept: 'application/json',
+            'X-Static-Header': 'value',
+          },
+          parameters: expect.objectContaining({
+            'X-Static-Parameter': 'value',
+          }),
         }),
       );
 

--- a/src/model/client/AbstractClient.ts
+++ b/src/model/client/AbstractClient.ts
@@ -23,6 +23,7 @@ import {
   type PaginatedEndpointResponse,
   type Options,
   type OptionsWithBody,
+  type OptionsWithoutBody,
 } from '@/model/client/AbstractClient.types';
 
 export const BASE_URL = 'https://api.myparcel.nl';
@@ -36,7 +37,7 @@ export abstract class AbstractClient {
    * @protected
    */
   public interceptors: {
-    request: Interceptors<RequestInit>;
+    request: Interceptors<OptionsWithBody<E> | OptionsWithoutBody<E>>;
     response: Interceptors<ResponseWrapper<EndpointResponseBody<AbstractEndpoint>>>;
   };
 

--- a/src/model/client/AbstractClient.ts
+++ b/src/model/client/AbstractClient.ts
@@ -37,7 +37,7 @@ export abstract class AbstractClient {
    * @protected
    */
   public interceptors: {
-    request: Interceptors<OptionsWithBody<E> | OptionsWithoutBody<E>>;
+    request: Interceptors<OptionsWithBody<AbstractEndpoint> | OptionsWithoutBody<AbstractEndpoint>>;
     response: Interceptors<ResponseWrapper<EndpointResponseBody<AbstractEndpoint>>>;
   };
 

--- a/src/model/client/FetchClient.ts
+++ b/src/model/client/FetchClient.ts
@@ -33,6 +33,10 @@ export class FetchClient extends AbstractClient {
       config = await interceptor(config);
     }
 
+    if (timeout && !config.signal) {
+      config.signal = timeoutController.signal;
+    }
+
     const response = await fetch(this.createUrl(endpoint, options), config);
     clearTimeout(id);
 


### PR DESCRIPTION
## description

- [x] Prevent when the interceptors are initialized the signal state is lost.