### PR TITLE
feat(endpoint): add useDataEnvelope opt-out

### DIFF
--- a/src/model/client/AbstractClient.spec.ts
+++ b/src/model/client/AbstractClient.spec.ts
@@ -6,6 +6,8 @@ import {POST_BODY_SHIPMENTS} from '@Test/mockData';
 import {createFetchMock} from '@Test/fetch/createFetchMock';
 import {TestPut204Endpoint} from '@Test/endpoints/TestPut204Endpoint';
 import {TestPostWithoutPropertyEndpoint} from '@Test/endpoints/TestPostWithoutPropertyEndpoint';
+import {TestPostNoEnvelopeEndpoint} from '@Test/endpoints/TestPostNoEnvelopeEndpoint';
+import {TestGetNoEnvelopeEndpoint} from '@Test/endpoints/TestGetNoEnvelopeEndpoint';
 import {TestGetTextEndpoint} from '@Test/endpoints/TestGetTextEndpoint';
 import {TestGetPdfEndpoint} from '@Test/endpoints/TestGetPdfEndpoint';
 import {TestGetPaginatedSizeEndpoint} from '@Test/endpoints/TestGetPaginatedSizeEndpoint';
@@ -231,6 +233,27 @@ describe('AbstractClient', () => {
       expect(fetchMock).toHaveBeenCalledWith('https://api.myparcel.nl/endpoint', {
         method: 'POST',
         body: '{"data":{"carrier":1,"options":{"package_type":1,"delivery_type":2},"recipient":{"cc":"NL","city":"Hoofddorp","person":"Ms. Parcel","street":"Antareslaan 31","postal_code":"2132 JE","email":"example@myparcel.nl"}}}',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        signal: expect.objectContaining({
+          aborted: false,
+        }),
+      });
+    });
+
+    it('sends body unwrapped when useDataEnvelope is false', async () => {
+      expect.assertions(1);
+
+      const sdk = createPublicSdk(new FetchClient(), [new TestPostNoEnvelopeEndpoint()]);
+      await sdk.postNoEnvelopeEndpoint({
+        body: {foo: 'bar', nested: {value: 1}},
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith('https://api.myparcel.nl/no-envelope', {
+        method: 'POST',
+        body: '{"foo":"bar","nested":{"value":1}}',
         headers: {
           Accept: 'application/json',
           'Content-Type': 'application/json',
@@ -482,6 +505,16 @@ describe('AbstractClient', () => {
 
     expect(response).toHaveProperty('token', 'test');
     expect(response).toHaveProperty('credentials', {username: 'test', password: 'test'});
+  });
+
+  it('returns response unwrapped when useDataEnvelope is false', async () => {
+    expect.assertions(2);
+
+    const sdk = createPublicSdk(new FetchClient(), [new TestGetNoEnvelopeEndpoint()]);
+    const response = await sdk.getNoEnvelopeEndpoint();
+
+    expect(response).toHaveProperty('token', 'test');
+    expect(response).toHaveProperty('nested', {value: 1});
   });
 
   it('returns size when size is defined', async () => {

--- a/src/model/client/AbstractClient.ts
+++ b/src/model/client/AbstractClient.ts
@@ -123,6 +123,10 @@ export abstract class AbstractClient {
     endpoint: E,
     response: EndpointResponse<E>,
   ): EndpointResponse<E> | PaginatedEndpointResponse<E> {
+    if (!endpoint.getUseDataEnvelope()) {
+      return response;
+    }
+
     if (!isOfType<ResponseWrapper<EndpointResponseBody<E>>>(response, 'data')) {
       return response;
     }
@@ -270,7 +274,9 @@ export abstract class AbstractClient {
         return newOptions;
       }
 
-      if (property === undefined) {
+      if (!endpoint.getUseDataEnvelope()) {
+        newOptions.body = options.body;
+      } else if (property === undefined) {
         newOptions.body = {
           data: options.body,
         };

--- a/src/model/endpoint/AbstractEndpoint.ts
+++ b/src/model/endpoint/AbstractEndpoint.ts
@@ -42,6 +42,14 @@ export abstract class AbstractEndpoint<D = EndpointDefinition> {
   public readonly timeout: number | undefined;
 
   /**
+   * Whether to wrap the request body in a `{ data: ... }` envelope and unwrap
+   * `response.data` from the response. Set to `false` for endpoints whose API
+   * does not use the data envelope; `property` and `responseProperty` are then
+   * also ignored, and the body is sent and returned as-is.
+   */
+  public readonly useDataEnvelope: boolean = true;
+
+  /**
    * Used to expose EndpointDefinition type.
    */
   public declare readonly definition: D;
@@ -83,5 +91,9 @@ export abstract class AbstractEndpoint<D = EndpointDefinition> {
 
   public getTimeout(): AbstractEndpoint['timeout'] {
     return this.timeout;
+  }
+
+  public getUseDataEnvelope(): AbstractEndpoint['useDataEnvelope'] {
+    return this.useDataEnvelope;
   }
 }

--- a/test/endpoints/TestGetNoEnvelopeEndpoint.ts
+++ b/test/endpoints/TestGetNoEnvelopeEndpoint.ts
@@ -1,0 +1,7 @@
+import {AbstractPublicEndpoint} from '@/model';
+
+export class TestGetNoEnvelopeEndpoint extends AbstractPublicEndpoint {
+  public readonly name = 'getNoEnvelopeEndpoint';
+  public readonly path = 'no-envelope';
+  public readonly useDataEnvelope = false;
+}

--- a/test/endpoints/TestPostNoEnvelopeEndpoint.ts
+++ b/test/endpoints/TestPostNoEnvelopeEndpoint.ts
@@ -1,0 +1,9 @@
+import {type HttpMethod} from '@/types';
+import {AbstractPublicEndpoint} from '@/model';
+
+export class TestPostNoEnvelopeEndpoint extends AbstractPublicEndpoint {
+  public readonly method: HttpMethod = 'POST';
+  public readonly name = 'postNoEnvelopeEndpoint';
+  public readonly path = 'no-envelope';
+  public readonly useDataEnvelope = false;
+}

--- a/test/fetch/examples/get-no-envelope.example.ts
+++ b/test/fetch/examples/get-no-envelope.example.ts
@@ -1,0 +1,16 @@
+// noinspection JSUnusedGlobalSymbols
+
+import {defineMockResponse} from '@Test/fetch/defineMockResponse';
+
+export default defineMockResponse({
+  match: (path: string, init?: RequestInit) => init?.method === 'GET' && path.startsWith('/no-envelope'),
+
+  response: () => ({
+    headers: {'Content-Type': 'application/json'},
+    status: 200,
+    body: {
+      token: 'test',
+      nested: {value: 1},
+    },
+  }),
+});

--- a/test/fetch/examples/post-no-envelope.example.ts
+++ b/test/fetch/examples/post-no-envelope.example.ts
@@ -1,0 +1,15 @@
+// noinspection JSUnusedGlobalSymbols
+
+import {defineMockResponse} from '@Test/fetch/defineMockResponse';
+
+export default defineMockResponse({
+  match: (path: string, init?: RequestInit) => init?.method === 'POST' && path === '/no-envelope',
+
+  response: () => ({
+    headers: {'Content-Type': 'application/json'},
+    status: 200,
+    body: {
+      ok: true,
+    },
+  }),
+});


### PR DESCRIPTION
## Summary
- Adds `useDataEnvelope: boolean` (default `true`) on `AbstractEndpoint` so endpoints can opt out of the `{ data: ... }` body wrapping in a non-breaking way.
- When set to `false`, `AbstractClient` sends the body as-is (no `data` envelope, no `property` nesting) and returns the response as-is (no unwrapping of `response.data`).
- `property` and `responseProperty` are part of the envelope contract, so they're ignored when the envelope is disabled.

## Test plan
- [x] Existing 83 tests still pass.
- [x] New test: request body is sent unwrapped when `useDataEnvelope = false`.
- [x] New test: response is returned as-is when `useDataEnvelope = false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)